### PR TITLE
Add Diffuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
 <li><a href="https://0data.app" title="Apps that let you own 100% of your data">Zero Data App</a></li>
 <li><a href="https://easyindie.app" title="Run your own X in a few clicks">Easy Indie</a></li>
 <li><a href="https://launchlet.dev" title="Customize any website with JavaScript or CSS.">Launchlet</a></li>
+<li><a href="https://diffuse.sh" title="A music player that connects to your cloud/distributed storage.">Diffuse</a></li>
 
 </ol>
 


### PR DESCRIPTION
Adds [Diffuse](https://diffuse.sh) to the list. The link to the app ring can be found at the bottom of [this page](https://diffuse.sh/about/#Misc).

Currently you have to pick the "browser" as your storage method to get started without an "account". I am planning to make this the default: https://github.com/icidasset/diffuse/issues/295
